### PR TITLE
Add support for Projects

### DIFF
--- a/pkg/cloud/cloud.go
+++ b/pkg/cloud/cloud.go
@@ -55,11 +55,12 @@ var (
 // client is the implementation of Interface.
 type client struct {
 	*cloudstack.CloudStackClient
+	projectID string
 }
 
 // New creates a new cloud connector, given its configuration.
 func New(config *Config) Interface {
 	csClient := cloudstack.NewAsyncClient(config.APIURL, config.APIKey, config.SecretKey, config.VerifySSL)
 
-	return &client{csClient}
+	return &client{csClient, config.ProjectID}
 }

--- a/pkg/cloud/config.go
+++ b/pkg/cloud/config.go
@@ -12,6 +12,7 @@ type Config struct {
 	APIKey    string
 	SecretKey string
 	VerifySSL bool
+	ProjectID string
 }
 
 // csConfig wraps the config for the CloudStack cloud provider.
@@ -40,6 +41,7 @@ func ReadConfig(configFilePath string) (*Config, error) {
 	return &Config{
 		APIURL:    cfg.Global.APIURL,
 		APIKey:    cfg.Global.APIKey,
+		ProjectID: cfg.Global.ProjectID,
 		SecretKey: cfg.Global.SecretKey,
 		VerifySSL: !cfg.Global.SSLNoVerify,
 	}, nil

--- a/pkg/cloud/vms.go
+++ b/pkg/cloud/vms.go
@@ -10,8 +10,12 @@ func (c *client) GetVMByID(ctx context.Context, vmID string) (*VM, error) {
 	logger := klog.FromContext(ctx)
 	p := c.VirtualMachine.NewListVirtualMachinesParams()
 	p.SetId(vmID)
+	if c.projectID != "" {
+		p.SetProjectid(c.projectID)
+	}
 	logger.V(2).Info("CloudStack API call", "command", "ListVirtualMachines", "params", map[string]string{
-		"id": vmID,
+		"id":        vmID,
+		"projectID": c.projectID,
 	})
 	l, err := c.VirtualMachine.ListVirtualMachines(p)
 	if err != nil {
@@ -24,7 +28,7 @@ func (c *client) GetVMByID(ctx context.Context, vmID string) (*VM, error) {
 		return nil, ErrTooManyResults
 	}
 	vm := l.VirtualMachines[0]
-
+	logger.V(2).Info("Returning VM", "vmID", vm.Id, "zoneID", vm.Zoneid)
 	return &VM{
 		ID:     vm.Id,
 		ZoneID: vm.Zoneid,

--- a/pkg/cloud/volumes.go
+++ b/pkg/cloud/volumes.go
@@ -41,8 +41,12 @@ func (c *client) GetVolumeByID(ctx context.Context, volumeID string) (*Volume, e
 	logger := klog.FromContext(ctx)
 	p := c.Volume.NewListVolumesParams()
 	p.SetId(volumeID)
+	if c.projectID != "" {
+		p.SetProjectid(c.projectID)
+	}
 	logger.V(2).Info("CloudStack API call", "command", "ListVolumes", "params", map[string]string{
-		"id": volumeID,
+		"id":        volumeID,
+		"projectid": c.projectID,
 	})
 
 	return c.listVolumes(p)
@@ -66,11 +70,15 @@ func (c *client) CreateVolume(ctx context.Context, diskOfferingID, zoneID, name 
 	p.SetZoneid(zoneID)
 	p.SetName(name)
 	p.SetSize(sizeInGB)
+	if c.projectID != "" {
+		p.SetProjectid(c.projectID)
+	}
 	logger.V(2).Info("CloudStack API call", "command", "CreateVolume", "params", map[string]string{
 		"diskofferingid": diskOfferingID,
 		"zoneid":         zoneID,
 		"name":           name,
 		"size":           strconv.FormatInt(sizeInGB, 10),
+		"projectid":      c.projectID,
 	})
 	vol, err := c.Volume.CreateVolume(p)
 	if err != nil {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

*Testing performed:*
- run `make all` or
- run `make container-cloudstack-csi-driver`
- renamed image cloudstack-csi-driver:master to pearl1594/cloudstack-csi-driver:project and pushed it to dockerhub
- deployed a cks cluster
- cloned csi repo onto control node
- update the controller-deployment.yaml and node-daemonset.yaml files at deploy/k8s/ and update the image to the one above
- apply storageclass, pvc and pod config after updating the custom diskoffering id in the storageclass yaml file in examples/k8s 
- view the logs of the cloudstack-csi-node pod running on a worker node - observe that the volume path is identified, mounted and attached for a cks cluster deployed in a project 



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
